### PR TITLE
removed flexible improper use

### DIFF
--- a/lib/Views/FeedBack/FeedBack.dart
+++ b/lib/Views/FeedBack/FeedBack.dart
@@ -331,17 +331,14 @@ class FeedBack extends StatelessWidget {
         padding: EdgeInsets.fromLTRB(16, 24, 16, 8),
         height: double.infinity,
         width: double.infinity,
-        child: Flexible(
-          flex: 1,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              _buildFeedbackContent(),
-              _buildNavigationFooter(),
-            ],
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            _buildFeedbackContent(),
+            _buildNavigationFooter(),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Situation
Release version of app running in Apple's TestFlight showing gray screen on Feedback Screen
## Context
In testing, app works fine in development mode but was graying out everything inside the container in the Feedback Screen when ran in TestFlight on iOS. After running the app and opening up DevTools I noticed this message in the console when loading Feedback Screen:
![image](https://user-images.githubusercontent.com/10569986/139557462-dcdb79cb-ab33-4681-8c28-928682490524.png)
## Decision
Old tree looked like this:
![image](https://user-images.githubusercontent.com/10569986/139557515-04ae61e1-1cdf-4f62-a01c-10a9dfccc718.png)
I decided to remove flexible from the tree and test to see if it would cause any breaking changes.
##Consequences
Upon removing nothing changes and the error in the console did not return. I believe this will fix the gray area issue in Apple's TestFlight and will be pushing this up for testing.