### PR TITLE
threshold update for pf

### DIFF
--- a/lib/Data/Standard.dart
+++ b/lib/Data/Standard.dart
@@ -2,7 +2,6 @@ import 'package:power_one/Models/PO1HustlePoint.dart';
 import 'package:power_one/Models/PO1Level.dart';
 import 'package:power_one/Models/PO1Point.dart';
 import 'package:power_one/Models/PO1User.dart';
-import 'package:power_one/Objects/Point.dart';
 
 class Standard {
   HustlePoint stl;
@@ -285,5 +284,13 @@ class Standard {
             .first[PO1User().playerLevel],
       },
     };
+  }
+
+  static miniThresholdByPlayerLevel() {
+    return PO1User().playerLevel == PO1Levels.GRADE
+        ? 5
+        : PO1User().playerLevel == PO1Levels.COLHIGH
+            ? 9
+            : 13;
   }
 }

--- a/lib/Objects/PO1Score.dart
+++ b/lib/Objects/PO1Score.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
+import 'package:power_one/Data/Standard.dart';
 import 'package:power_one/Data/constants.dart';
 import 'package:power_one/Models/PO1PlayerSkill.dart';
 import 'package:power_one/Objects/Play.dart';
@@ -197,7 +198,8 @@ class PO1Score extends ChangeNotifier {
   }
 
   bool metPlaytimeThreshold() {
-    if (history.length >= minimumThreshold) {
+    if ((history.length - _hustlePointsMap['PF'].pos) >=
+        Standard.miniThresholdByPlayerLevel()) {
       return true;
     }
 

--- a/lib/Views/PlayerName/PlayerNameForm.dart
+++ b/lib/Views/PlayerName/PlayerNameForm.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:power_one/Data/Standard.dart';
 import 'package:power_one/Data/constants.dart';
 import 'package:power_one/Main.dart';
 import 'package:power_one/Models/PO1Level.dart';


### PR DESCRIPTION
Additional requirements for the mini threshold were added by the Dixons in our meeting yesterday. 
The new minimal threshold requirements are below:

---
title: PO1Grade Minimal Threshold
---
| Ele/Mid | High/Col | Pro |
| :-------: | :---------: | :-----: |
| 5 | 9 | 13 |

Also, with the addition of personal fouls (PF)s the calculations should be alter. PFs are not to be add with the overall score and should also not go towards actions needed to meet the minimal threshold.