### PR TITLE
Remove broken code from android

### DIFF
--- a/android/app/src/main/kotlin/com/power_of_one/basketball/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/power_of_one/basketball/MainActivity.kt
@@ -9,15 +9,4 @@ class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine);
     }
-    
-    @Override
-+    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-+        GeneratedPluginRegistrant.registerWith(flutterEngine);
-+        new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), CHANNEL)
-+                .setMethodCallHandler(
-+                    (call, result) -> {
-+                        // Your existing code
-+                }
-+        );
-+    }
 }


### PR DESCRIPTION
After ios v1.0.0 release, while trying to fix a subscription bug, running the app locally in vscode would throw an error.

This fix remove the code that was causing the error. 

I was able to test after the changes were in and app now runs in debug mode 